### PR TITLE
Add llms.txt for LLM-friendly site navigation

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,18 @@
+# Physioshark Project
+> The Physioshark Project, led by Dr. Jodie Rummer at James Cook University, investigates how climate change impacts the physiology of newborn and juvenile reef sharks in Moorea, French Polynesia, to inform conservation strategies.
+
+Fieldwork is based at the CRIOBE Research Center. The project studies physiological energetics of newborn blacktip reef and sicklefin lemon sharks across nursery areas around Moorea, including responses to warming, low oxygen, and elevated CO2.
+
+## Pages
+- [Home](https://physioshark.org/): Project overview and entry point for all sections
+- [Our Mission](https://physioshark.org/#our-mission): Mission to protect future generations of sharks under climate change
+- [Projects](https://physioshark.org/#projects): Research, community education, and ways to get involved
+- [Publications](https://physioshark.org/#publications): Scientific publications from the Physioshark research program
+- [Team](https://physioshark.org/#team): Project team members and researcher profiles
+- [Contact](https://physioshark.org/#contact): Contact form and project inquiries
+
+## Optional
+- [RummerLab](https://rummerlab.com/): Parent research laboratory website
+- [Dr. Jodie Rummer](https://jodierummer.com/): Personal site for the project lead
+- [Partners](https://physioshark.org/#partners): Supporting organizations and partners
+- [GitHub repository](https://github.com/RummerLab/Physioshark-Project): Source code for this website


### PR DESCRIPTION
## Summary
- Add `public/llms.txt` served at `/llms.txt` following the [llms.txt](https://llmstxt.org/) spec
- Curated index of single-page sections (`#our-mission`, `#projects`, etc.) and related sites

## Test plan
- [ ] After deploy, confirm https://physioshark.org/llms.txt returns 200
- [ ] Confirm Content-Type is text/plain and content matches the file