### PR TITLE
Update Physioshark fieldwork to Mo'orea and science4reefs

### DIFF
--- a/app/components/Mission.tsx
+++ b/app/components/Mission.tsx
@@ -26,7 +26,7 @@ export default function Mission() {
             </p>
             
             <p>
-              The fieldwork is now based on Mo&apos;orea (Island) in French Polynesia, in collaboration with{' '}
+              The fieldwork is now based on Mo&apos;orea, French Polynesia, in collaboration with{' '}
               <a
                 href="https://www.science4reefs-cnrs.com/"
                 target="_blank"

--- a/app/components/Mission.tsx
+++ b/app/components/Mission.tsx
@@ -26,7 +26,16 @@ export default function Mission() {
             </p>
             
             <p>
-              The fieldwork is based at the CRIOBE Research Center on Moorea, French Polynesia. The project 
+              The fieldwork is now based on Mo&apos;orea (Island) in French Polynesia, in collaboration with{' '}
+              <a
+                href="https://www.science4reefs-cnrs.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:text-blue-800 underline"
+              >
+                science4reefs
+              </a>
+              . The project 
               investigates the physiological energetics (i.e., costs/benefits) of newborn blacktip reef and 
               sicklefin lemon sharks living in the 11 potential nursery areas identified around the island. 
               For instance, the research team is investigating how well newborn sharks cope with hot water 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,7 +1,7 @@
 # Physioshark Project
 > The Physioshark Project, led by Dr. Jodie Rummer at James Cook University, investigates how climate change impacts the physiology of newborn and juvenile reef sharks on Mo'orea, French Polynesia, to inform conservation strategies.
 
-Fieldwork is now based on Mo'orea (Island) in collaboration with science4reefs (https://www.science4reefs-cnrs.com/). The project studies physiological energetics of newborn blacktip reef and sicklefin lemon sharks across nursery areas around the island, including responses to warming, low oxygen, and elevated CO2.
+Fieldwork is now based on Mo'orea, French Polynesia, in collaboration with science4reefs (https://www.science4reefs-cnrs.com/). The project studies physiological energetics of newborn blacktip reef and sicklefin lemon sharks across nursery areas around the island, including responses to warming, low oxygen, and elevated CO2.
 
 ## Pages
 - [Home](https://physioshark.org/): Project overview and entry point for all sections
@@ -14,6 +14,6 @@ Fieldwork is now based on Mo'orea (Island) in collaboration with science4reefs (
 ## Optional
 - [RummerLab](https://rummerlab.com/): Parent research laboratory website
 - [Dr. Jodie Rummer](https://jodierummer.com/): Personal site for the project lead
-- [science4reefs](https://www.science4reefs-cnrs.com/): Current fieldwork collaboration on Mo'orea
+- [science4reefs](https://www.science4reefs-cnrs.com/): Current fieldwork collaboration on Mo'orea, French Polynesia
 - [Partners](https://physioshark.org/#partners): Supporting organizations and partners
 - [GitHub repository](https://github.com/RummerLab/Physioshark-Project): Source code for this website

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,7 +1,7 @@
 # Physioshark Project
-> The Physioshark Project, led by Dr. Jodie Rummer at James Cook University, investigates how climate change impacts the physiology of newborn and juvenile reef sharks in Moorea, French Polynesia, to inform conservation strategies.
+> The Physioshark Project, led by Dr. Jodie Rummer at James Cook University, investigates how climate change impacts the physiology of newborn and juvenile reef sharks on Mo'orea, French Polynesia, to inform conservation strategies.
 
-Fieldwork is based at the CRIOBE Research Center. The project studies physiological energetics of newborn blacktip reef and sicklefin lemon sharks across nursery areas around Moorea, including responses to warming, low oxygen, and elevated CO2.
+Fieldwork is now based on Mo'orea (Island) in collaboration with science4reefs (https://www.science4reefs-cnrs.com/). The project studies physiological energetics of newborn blacktip reef and sicklefin lemon sharks across nursery areas around the island, including responses to warming, low oxygen, and elevated CO2.
 
 ## Pages
 - [Home](https://physioshark.org/): Project overview and entry point for all sections
@@ -14,5 +14,6 @@ Fieldwork is based at the CRIOBE Research Center. The project studies physiologi
 ## Optional
 - [RummerLab](https://rummerlab.com/): Parent research laboratory website
 - [Dr. Jodie Rummer](https://jodierummer.com/): Personal site for the project lead
+- [science4reefs](https://www.science4reefs-cnrs.com/): Current fieldwork collaboration on Mo'orea
 - [Partners](https://physioshark.org/#partners): Supporting organizations and partners
 - [GitHub repository](https://github.com/RummerLab/Physioshark-Project): Source code for this website


### PR DESCRIPTION
## Summary
- Fieldwork is now based on Mo'\''orea (Island) in collaboration with [science4reefs](https://www.science4reefs-cnrs.com/)
- Remove CRIOBE as the current field base in the mission copy and `llms.txt`

## Test plan
- [ ] Confirm https://physioshark.org/#our-mission no longer says CRIOBE is the fieldwork base
- [ ] Confirm science4reefs is linked
- [ ] Confirm https://physioshark.org/llms.txt matches after deploy