### PR TITLE
Fix Dependabot alert: bump nanoid to 3.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6022,9 +6022,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
     "dompurify": "^3.4.13",
+    "nanoid": "^3.3.18",
     "postcss": "^8.5.26"
   }
 }


### PR DESCRIPTION
## Summary
- Override transitive `nanoid` to `^3.3.18` to resolve Dependabot alert #73 (CVE-2026-67213: custom generators can loop indefinitely when size is zero).
- Refresh `package-lock.json` so the resolved version is `3.3.18`.

## Test plan
- [x] Confirm `package-lock.json` resolves `nanoid` to `3.3.18`
- [x] `npm audit --package-lock-only` reports 0 vulnerabilities
- [ ] CI passes on the PR