### PR TITLE
chore: release 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "physioshark-project",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "physioshark-project",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@next/third-parties": "16.3.0",
         "@vercel/analytics": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "physioshark-project",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
Bump package.json version to 0.1.2 for release v0.1.2.

Made with [Cursor](https://cursor.com)